### PR TITLE
Correct SHORTVERSION for PATCH part has more than 2 characters

### DIFF
--- a/install-php-mecab.sh
+++ b/install-php-mecab.sh
@@ -14,7 +14,7 @@ OUTPUT=$(php --version)
 
 LONGVERSION=$(echo $OUTPUT | cut -d ' ' -f2 | cut -d '-' -f1)
 
-SHORTVERSION=${LONGVERSION%??}
+SHORTVERSION=${LONGVERSION%.*}
 
 echo $SHORTVERSION
 


### PR DESCRIPTION
Currently,

```
SHORTVERSION=${LONGVERSION%??}
```

won't work if there're more than 1 character in PATCH part in LONGVERSION.
Ex: If LONGVERSION is `7.1.10`, SHORTVERSION will be `7.1.` which should be `7.1`